### PR TITLE
Fix en /(account)/login/callback/page - useSearchParams() error build

### DIFF
--- a/src/app/(account)/account/login/callback/page.tsx
+++ b/src/app/(account)/account/login/callback/page.tsx
@@ -1,10 +1,9 @@
 "use client"
-import { useEffect } from "react";
+import { useEffect, Suspense } from "react";
 import { setSession } from "@/app/actions";
-import { useRouter } from "next/navigation";
-import { useSearchParams } from "next/navigation";
+import { useSearchParams, useRouter } from "next/navigation";
 
-export default function loginCallback() {
+function LoginCallbackContent() {
     const router = useRouter();
     const searchParams = useSearchParams();
     const returnUrl = searchParams.get('return_url') || '/';
@@ -34,4 +33,12 @@ export default function loginCallback() {
     }, []);
 
     return <div>loginCallback</div>;
+}
+
+export default function LoginCallback() {
+    return (
+        <Suspense fallback={<div>Loading...</div>}>
+            <LoginCallbackContent />
+        </Suspense>
+    );
 }


### PR DESCRIPTION
# Corrección: Envolver `useSearchParams()` en `Suspense` para `/account/login/callback`

## Problema
Al prerenderizar la página `/account/login/callback` se producía el error:

useSearchParams() should be wrapped in a suspense boundary


Esto ocurría porque `useSearchParams()` se estaba utilizando directamente en un componente prerenderizado, lo que provocaba que la build fallara.

## Solución
Se creó un componente separado que contiene la lógica de login callback y se envolvió en un `Suspense`. Esto permite que la página prerenderice correctamente y se maneje la lógica de redirección y establecimiento de sesión del usuario de manera segura.

## Resultado
- La build de OpenNextJS con Cloudflare ahora se completa sin errores.
- La página `/account/login/callback` funciona correctamente.
- Se evita el error de prerendering con `useSearchParams()`.


