### PR TITLE
Actualize nextjs a la 14.2.33, @opennextjs/cloudflare a la 1.9.1 y  supabase a la 2.58.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
 	"scripts": {
 		"dev": "next dev",
 		"build": "next build",
-		"start": "next start",
 		"deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
 		"preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
 		"cf-typegen": "wrangler types --env-interface CloudflareEnv ./cloudflare-env.d.ts"
@@ -15,15 +14,15 @@
 		"@emotion/react": "11.14.0",
 		"@emotion/styled": "11.14.1",
 		"@mercadopago/sdk-react": "1.0.6",
-		"@opennextjs/cloudflare": "1.3.0",
-		"@supabase/supabase-js": "2.57.4",
+		"@opennextjs/cloudflare": "1.9.1",
+		"@supabase/supabase-js": "2.58.0",
 		"jose": "6.1.0",
-		"next": "14.2.32",
-		"react": "18.0.0",
-		"react-dom": "18.0.0"
+		"next": "14.2.33",
+		"react": "18.3.1",
+		"react-dom": "18.3.1"
 	},
 	"devDependencies": {
-		"@types/node": "20.19.17",
+		"@types/node": "20.19.19",
 		"@types/react": "19",
 		"@types/react-dom": "19",
 		"typescript": "5",


### PR DESCRIPTION
Esta solicitud de extracción actualiza varias dependencias en «package.json» a sus últimas versiones y elimina el script «start» que no se utiliza. Estos cambios ayudan a mantener el proyecto actualizado y pueden incluir correcciones de errores importantes y mejoras de rendimiento.

Actualizaciones de dependencias:

* Se ha actualizado `@opennextjs/cloudflare` de la versión 1.3.0 a la 1.9.1, `@supabase/supabase-js` de la 2.57.4 a la 2.58.0, `next` de la 14.2.32 a la 14.2.33, `react` y `react-dom` de la versión 18.0.0 a la 18.3.1, y `@types/node` de la versión 20.19.17 a la 20.19.19.

Limpieza de scripts:

* Se ha eliminado el script `start` de la sección `scripts`, ya que ya no es necesario.